### PR TITLE
fix(useElementSize): use object instead of experimental DOMRectReadonly

### DIFF
--- a/packages/useElementSize/src/useElementSize.ts
+++ b/packages/useElementSize/src/useElementSize.ts
@@ -1,20 +1,30 @@
 import { useState, useLayoutEffect } from 'react'
 import ResizeObserver from 'resize-observer-polyfill'
 
+interface SizeRectReadonly {
+  readonly x: number
+  readonly y: number
+  readonly width: number
+  readonly height: number
+}
+
 export default function useElementSize(): [
   (node: HTMLElement | null) => void,
-  DOMRectReadOnly
+  SizeRectReadonly
 ] {
   const [nodeRef, setRef] = useState<HTMLElement | null>(null)
-  const [elementSize, setElementSize] = useState<DOMRectReadOnly>(
-    new DOMRectReadOnly(0, 0, 0, 0),
-  )
-
+  const [elementSize, setElementSize] = useState<SizeRectReadonly>({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+  })
   useLayoutEffect(() => {
     if (nodeRef) {
-      const ro = new ResizeObserver(([entry]: Array<ResizeObserverEntry>) =>
-        setElementSize(entry.contentRect as DOMRectReadOnly),
-      )
+      const ro = new ResizeObserver(([entry]: Array<ResizeObserverEntry>) => {
+        const { x, y, width, height } = entry.contentRect
+        setElementSize({ x, y, width, height })
+      })
       ro.observe(nodeRef)
 
       return () => {


### PR DESCRIPTION
Use plain object instead of experimental DOMRectReadonly, which caused implementations to fail in jest, as JSDom doesn't have typings for it