### PR TITLE
Add error handling to useScript hook

### DIFF
--- a/packages/useScript/readme.md
+++ b/packages/useScript/readme.md
@@ -15,7 +15,7 @@ yarn add @charlietango/use-script
 ## API
 
 ```js
-const ready = useScript(url)
+const [ready, error] = useScript(url)
 ```
 
 ## Example
@@ -25,7 +25,12 @@ import React from 'react'
 import useScript from '@charlietango/use-script'
 
 const Component = () => {
-  const scriptReady = useScript('https://api.google.com/api.js')
+  const [scriptReady, scriptError] = useScript('https://api.google.com/api.js')
+
+  if (scriptError) {
+    return <div>Failed to load Google API Ready.</div>
+  }
+
   return <div>Google API Ready: {scriptReady}</div>
 }
 

--- a/packages/useScript/src/useScript.story.tsx
+++ b/packages/useScript/src/useScript.story.tsx
@@ -4,7 +4,7 @@ import { action } from '@storybook/addon-actions'
 import useScript from './useScript'
 
 const ScriptComponent = () => {
-  const ready = useScript('/js/external.js')
+  const [ready] = useScript('/js/external.js')
   useEffect(() => {
     action('script ready')(ready)
   }, [ready])

--- a/packages/useScript/src/useScript.test.js
+++ b/packages/useScript/src/useScript.test.js
@@ -21,7 +21,8 @@ it('should load the external script', () => {
   })
   rerender()
   expect(script).toHaveAttribute('data-loaded', 'true')
-  expect(result.current).toBe(true)
+  expect(result.current[0]).toBe(true)
+  expect(result.current[1]).toBe(undefined)
 })
 
 it('should handle errors when loading', () => {
@@ -29,12 +30,15 @@ it('should handle errors when loading', () => {
   let script = document.querySelector(`script[src="${url}"]`)
   expect(script).toBeDefined()
 
-  // Fire the error event
-  fireEvent(script, new Event('error'))
+  act(() => {
+    // Fire the error event
+    fireEvent(script, new Event('error'))
+  })
 
   rerender()
   expect(script).toHaveAttribute('data-failed', 'true')
-  expect(result.current).toBe(false)
+  expect(result.current[0]).toBe(false)
+  expect(result.current[1]).toBe(true)
 })
 
 it('should not create more then one script entry', () => {

--- a/packages/useScript/src/useScript.ts
+++ b/packages/useScript/src/useScript.ts
@@ -1,23 +1,26 @@
 import { useEffect, useReducer } from 'react'
 
+enum ScriptStatus {
+  LOADED = 'loaded',
+  ERROR = 'error',
+}
+
+type Action = {
+  type: ScriptStatus
+}
+
 type State = {
   ready: boolean
   error?: boolean
 }
 
-type Action = {
-  type: string
-}
-
-const SCRIPT_LOADED: string = 'SCRIPT_LOADED'
-const SCRIPT_LOAD_ERROR: string = 'SCRIPT_LOAD_ERROR'
 const INITIAL_STATE: State = { ready: false, error: undefined }
 
 function scriptLoadReducer(state: State, action: Action): State {
   switch (action.type) {
-    case SCRIPT_LOADED:
+    case ScriptStatus.LOADED:
       return { ...INITIAL_STATE, ready: true }
-    case SCRIPT_LOAD_ERROR:
+    case ScriptStatus.ERROR:
       return { ...INITIAL_STATE, error: true }
     default: {
       throw new Error('Invalid action dispatched.')
@@ -42,12 +45,12 @@ export default function useScript(url: string): [boolean, boolean?] {
   useEffect(() => {
     function onReady() {
       // The ready event is fired whenever the resource is loaded, but it doesn't know if it was successful
-      dispatch({ type: SCRIPT_LOADED })
+      dispatch({ type: ScriptStatus.LOADED })
     }
 
     function onError() {
       // The ready event is fired whenever the resource is loaded, but it doesn't know if it was successful
-      dispatch({ type: SCRIPT_LOAD_ERROR })
+      dispatch({ type: ScriptStatus.ERROR })
     }
 
     let script: HTMLScriptElement | null = document.querySelector(

--- a/packages/useScript/src/useScript.ts
+++ b/packages/useScript/src/useScript.ts
@@ -49,7 +49,7 @@ export default function useScript(url: string): [boolean, boolean?] {
     }
 
     function onError() {
-      // The ready event is fired whenever the resource is loaded, but it doesn't know if it was successful
+      // The ready event is fired whenever the resource errors-out
       dispatch({ type: ScriptStatus.ERROR })
     }
 

--- a/packages/useScript/src/useScript.ts
+++ b/packages/useScript/src/useScript.ts
@@ -1,4 +1,31 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useReducer } from 'react'
+
+type State = {
+  ready: boolean
+  error?: boolean
+}
+
+type Action = {
+  type: string
+}
+
+const SCRIPT_LOADED: string = 'SCRIPT_LOADED'
+const SCRIPT_LOAD_ERROR: string = 'SCRIPT_LOAD_ERROR'
+const INITIAL_STATE: State = { ready: false, error: undefined }
+
+function scriptLoadReducer(state: State, action: Action): State {
+  switch (action.type) {
+    case SCRIPT_LOADED:
+      return { ...INITIAL_STATE, ready: true }
+    case SCRIPT_LOAD_ERROR:
+      return { ...INITIAL_STATE, error: true }
+    default: {
+      throw new Error('Invalid action dispatched.')
+    }
+  }
+}
+
+function noop() {}
 
 /**
  * Hook to load an external script. Returns true once the script has finished loading.
@@ -6,13 +33,21 @@ import { useEffect, useState } from 'react'
  * @param {string} url The external script to load
  * @return boolean True if the script has been loaded
  * */
-export default function useScript(url: string): boolean {
-  const [ready, setReady] = useState<boolean>(false)
+export default function useScript(url: string): [boolean, boolean?] {
+  const [{ ready, error }, dispatch] = useReducer(
+    scriptLoadReducer,
+    INITIAL_STATE,
+  )
 
   useEffect(() => {
     function onReady() {
       // The ready event is fired whenever the resource is loaded, but it doesn't know if it was successful
-      setReady(true)
+      dispatch({ type: SCRIPT_LOADED })
+    }
+
+    function onError() {
+      // The ready event is fired whenever the resource is loaded, but it doesn't know if it was successful
+      dispatch({ type: SCRIPT_LOAD_ERROR })
     }
 
     let script: HTMLScriptElement | null = document.querySelector(
@@ -33,19 +68,29 @@ export default function useScript(url: string): boolean {
       }
     } else {
       if (script.getAttribute('data-loaded') === 'true') {
-        setReady(true)
+        onReady()
         // Already loaded, so we can return early
-        return () => {}
+        return noop
+      }
+
+      if (script.getAttribute('data-failed') === 'true') {
+        onError()
+        // Already tried loading, so we can return early
+        return noop
       }
     }
 
     // Add load event listener
     script.addEventListener('load', onReady)
+    script.addEventListener('error', onError)
 
     return () => {
-      if (script) script.removeEventListener('load', onReady)
+      if (script) {
+        script.removeEventListener('load', onReady)
+        script.removeEventListener('error', onError)
+      }
     }
   }, [url])
 
-  return ready
+  return [ready, error]
 }

--- a/packages/useScript/src/useScript.ts
+++ b/packages/useScript/src/useScript.ts
@@ -28,8 +28,6 @@ function scriptLoadReducer(state: State, action: Action): State {
   }
 }
 
-function noop() {}
-
 /**
  * Hook to load an external script. Returns true once the script has finished loading.
  *
@@ -71,15 +69,13 @@ export default function useScript(url: string): [boolean, boolean?] {
       }
     } else {
       if (script.getAttribute('data-loaded') === 'true') {
-        onReady()
         // Already loaded, so we can return early
-        return noop
+        return onReady()
       }
 
       if (script.getAttribute('data-failed') === 'true') {
-        onError()
         // Already tried loading, so we can return early
-        return noop
+        return onError()
       }
     }
 


### PR DESCRIPTION
If there is an issue with loading the script (e.g. invalid URL), then the hook always returns `false`, but an error have already occurred. This makes it hard to handle errors in your components.