### PR TITLE
Fix lazy load example

### DIFF
--- a/packages/useNativeLazyLoading/readme.md
+++ b/packages/useNativeLazyLoading/readme.md
@@ -35,7 +35,7 @@ const LazyImage = ({ width, height, src, ...rest }) => {
 
   return (
     <div
-      ref={supportsLazyLoading === false ? ref : undefined}
+      ref={!supportsLazyLoading ? ref : undefined}
       style={{
         position: 'relative',
         paddingBottom: `${(height / width) * 100}%`,


### PR DESCRIPTION
Since Version 1.7.0. the hook returns undefined or false, so for the
example to work you need to change the check from supportsLazyLoading ===
false to !supportsLazyLoading