### PR TITLE
fix(useScript): apply attributes before appending script to DOM

### DIFF
--- a/packages/useScript/src/useScript.ts
+++ b/packages/useScript/src/useScript.ts
@@ -49,12 +49,12 @@ export default function useScript(url?: string, options?: {
       script.src = url
       script.async = true
       script.setAttribute('data-status', ScriptStatus.LOADING)
-      document.head.appendChild(script)
       if (attributes) {
         Object.keys(attributes).forEach(key => {
           script?.setAttribute(key, attributes[key])
         })
       }
+      document.head.appendChild(script)
 
       // Ensure the status is loading
       setStatus(ScriptStatus.LOADING)


### PR DESCRIPTION
When using security focused attributes for scripts such as `nonce`, these values need to be set on the element **before** it is appended to the DOM.  Setting afterwards breaks the security model and the browser will reject executing the script.

**Currently**
![Screen Shot 2022-04-14 at 3 43 34 PM](https://user-images.githubusercontent.com/6364918/163465478-71a394c3-b1a7-4088-9dbe-a052f1835941.png)

**With Change**
![Screen Shot 2022-04-14 at 3 43 05 PM](https://user-images.githubusercontent.com/6364918/163465499-d419c2ee-5c7d-4f71-8244-6c69679d1332.png)

Notice the value of the nonce is now hidden meaning Chrome has accepted it and masked the value for security reasons.