### PR TITLE
fix: expand opts to deps, so hook isn't recreated

### DIFF
--- a/src/__tests__/useDebouncedCallback.test.tsx
+++ b/src/__tests__/useDebouncedCallback.test.tsx
@@ -133,3 +133,12 @@ test("should infer the correct callback signature", async () => {
   expectTypeOf(result.current).parameter(1).toMatchTypeOf<number>();
   expectTypeOf(result.current).parameter(2).toMatchTypeOf<{ input: string }>();
 });
+
+test("should not recreate the hook on each render", () => {
+  const cb = vi.fn();
+  const { result, rerender } = renderHook(() => useDebouncedCallback(cb, 500));
+  const firstValue = result.current;
+  rerender();
+  // Validate that we didn't recreate he debounced function. It should stay the same, until the options change
+  expect(firstValue).toBe(result.current);
+});

--- a/src/hooks/useDebouncedCallback.ts
+++ b/src/hooks/useDebouncedCallback.ts
@@ -113,5 +113,5 @@ export function useDebouncedCallback<
     };
 
     return debounce;
-  }, [wait, options]);
+  }, [wait, options.trailing, options.leading]);
 }


### PR DESCRIPTION
The `useDebouncedCallback` recreated the memorized function on each render, since it was using the entire `options` as a dependency, instead of the individual option values.